### PR TITLE
Fix displaying of images in reports with fails

### DIFF
--- a/hybrid_report.py
+++ b/hybrid_report.py
@@ -4,6 +4,7 @@ from shutil import copyfile, copytree
 import os
 import jinja2
 import time
+from glob import glob
 
 
 def env_override(value, key):
@@ -38,24 +39,34 @@ def main():
         print(str(err))
         exit(-1)
 
+    images = []
+    ref_images = set(glob(os.path.join(args.images_basedir, ref_dir, "*")))
+    out_images = set(glob(os.path.join(args.images_basedir, out_dir, "*")))
+    for images_paths in [ref_images, out_images]:
+        for image_path in images_paths:
+            image = os.path.basename(image_path)
+            if image not in images:
+                images.append(os.path.basename(image_path))
+
     for suite in xml:
         for case in suite:
             if case.result:
-                img_name = case.result.message.splitlines()[-1]
-
-                if not os.path.exists(os.path.join(args.images_basedir, ref_dir, img_name)) and not os.path.exists(os.path.join(args.images_basedir, out_dir, img_name)):
-                    cases_list.append(case.name + img_name)
-                else:
-                    cases_list.append(img_name)
-                    for target_dir in [ref_dir, out_dir]:
-                        source_img_path = os.path.join(args.images_basedir, target_dir, img_name)
-                        report_img_path = os.path.join(args.report_path, target_dir, img_name)
-                        if os.path.exists(source_img_path):
-                            try:
-                                copyfile(source_img_path, report_img_path)
-                            except OSError as err:
-                                print(str(err))
-                                print(img_name)
+                image_found = False
+                for image in images:
+                    if image.startswith(case.name):
+                        cases_list.append(image)
+                        image_found = True
+                        for target_dir in [ref_dir, out_dir]:
+                            source_img_path = os.path.join(args.images_basedir, target_dir, image)
+                            report_img_path = os.path.join(args.report_path, target_dir, image)
+                            if os.path.exists(source_img_path):
+                                try:
+                                    copyfile(source_img_path, report_img_path)
+                                except OSError as err:
+                                    print(str(err))
+                                    print(image)
+                if not image_found:
+                    cases_list.append(image)
 
     env = jinja2.Environment(
         loader=jinja2.PackageLoader('hybrid_report', 'templates'),


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-1710
### Purpose
* Fix displaying of images in reports with fails
### Effect of change
* Display all images which starts with name of failed cases
### Jenkins Builds
* https://rpr.cis.luxoft.com/job/RadeonProRender-HybridManual/519/