### PR TITLE
Improve diff loading

### DIFF
--- a/resources/js/images-substr.js
+++ b/resources/js/images-substr.js
@@ -80,6 +80,7 @@ async function renderCanvasData(baselineId, renderId, diffCanvasId, thresholdVal
     let diff = ctx.createImageData(width, height);
     pixelmatch(imgData1.data, imgData2.data, diff.data, width, height, {threshold: this.thresholdValue});
     ctx.putImageData(diff, 0, 0);
+    console.log("Done")
 }
 
 function renderCanvasReshalla(baselineId, renderId) {

--- a/resources/js/images-substr.js
+++ b/resources/js/images-substr.js
@@ -63,13 +63,8 @@ async function renderCanvasData(baselineId, renderId, diffCanvasId, thresholdVal
     await waitImageLoading(baselineImg);
     await waitImageLoading(renderedImg);
 
-    var width1 = renderedImg.naturalWidth || renderedImg.width;
-    var width2 = baselineImg.naturalWidth || baselineImg.width;
-    let width = Math.max(width1, width2);
-
-    var height1 = renderedImg.naturalHeight || renderedImg.height;
-    var height2 = baselineImg.naturalHeight || baselineImg.height;
-    let height = Math.max(height1, height2);
+    let width = baselineImg.naturalWidth || baselineImg.width;
+    let height = baselineImg.naturalHeight || baselineImg.height;
 
     diffCanvas.width = width;
     diffCanvas.height = height;

--- a/resources/js/images-substr.js
+++ b/resources/js/images-substr.js
@@ -42,12 +42,10 @@ function showImagesSubtraction(baselineId, renderId, reshalla) {
 
 function waitImageLoading(img) {
     return new Promise(resolve => {
-        console.log({wait_for_image: img});
         if (img.complete) {
             resolve();
         } else {
             img.addEventListener("load", () => {
-                console.log({imgLoaded: img});
                 resolve()
             });
         }
@@ -80,7 +78,6 @@ async function renderCanvasData(baselineId, renderId, diffCanvasId, thresholdVal
     let diff = ctx.createImageData(width, height);
     pixelmatch(imgData1.data, imgData2.data, diff.data, width, height, {threshold: this.thresholdValue});
     ctx.putImageData(diff, 0, 0);
-    console.log("Done")
 }
 
 function renderCanvasReshalla(baselineId, renderId) {

--- a/resources/js/images-substr.js
+++ b/resources/js/images-substr.js
@@ -78,7 +78,7 @@ async function renderCanvasData(baselineId, renderId, diffCanvasId, thresholdVal
     let imgData2 = ctx.getImageData(0, 0, width, height);
 
     let diff = ctx.createImageData(width, height);
-    pixelmatch(imgData1.data, imgData2.data, diff.data, width, height, {threshold: this.thresholdValue});
+    pixelmatch(imgData1.data, imgData2.data, diff.data, width, height, {threshold: thresholdValue});
     ctx.putImageData(diff, 0, 0);
 }
 

--- a/resources/js/images-substr.js
+++ b/resources/js/images-substr.js
@@ -58,6 +58,8 @@ async function renderCanvasData(baselineId, renderId, diffCanvasId, thresholdVal
     var renderedImg = document.getElementById(renderId);
     var diffCanvas = document.getElementById(diffCanvasId);
 
+    if (!baselineImg | !renderedImg) return;
+
     await waitImageLoading(baselineImg);
     await waitImageLoading(renderedImg);
 

--- a/templates/main_template.html
+++ b/templates/main_template.html
@@ -129,7 +129,7 @@
             </thead>
             <tbody>
                 {% for case in cases_list %}
-                <tr>
+                <tr id="TRow{{ loop.index }}">
                     <td>{{ case['name'] }}</td>
                     <td>
                         <button class="btn btn-default" type="button" name="copyTestCaseNameButton" style="max-width: 15vw; margin: auto; display: block; white-space: break-spaces; overflow-wrap: break-word;">{{ case['name'] }}</button>
@@ -147,11 +147,6 @@
                                         oninput="renderCanvasData('Ref{{ loop.index }}', 'Out{{ loop.index }}', 'Diff{{ loop.index }}', this.value);"/>
                                 <output for="thresholdSelector{{ loop.index }}" name="currentThresholdView{{ loop.index }}">0.0</output>
                             </form>
-                            <script>
-                                window.setTimeout( function(){
-                                    waitImgLoadAndRenderCanvasData('Ref{{ loop.index }}', 'Out{{ loop.index }}', 'Diff{{ loop.index }}', 0.0);
-                                }, 100* {{ loop.index }} );
-                            </script>
                         </td>
                     {% else %}
                         <td class="text">{{ case['reason'] }}</td>
@@ -172,3 +167,17 @@
 
 </body>
 </html>
+
+<script>
+    let table = $('#mainTable')[0];
+    let rows = table.rows;
+    let order = rows.map(row => +row.id.replace("TRow"));
+
+    $(document).ready(function() {
+        order.forEach(index => {
+            setTimeout(function () {
+                renderCanvasData(`Ref${index}`, `Out${index}`, `Diff${index}`, 0.0)
+            }, 100);
+        });
+    })
+</script>

--- a/templates/main_template.html
+++ b/templates/main_template.html
@@ -169,16 +169,12 @@
 </html>
 
 <script>
-    let table = $('#mainTable')[0];
-    let rows = [...table.rows];
-    let order = rows.map(row => +row.id.replace("TRow")).filter(row => !isNaN(row));
-    console.log({orderLen: order.length})
-
     $(document).ready(function() {
-        order.forEach(index => {
+        for (var i = 1; i <= {{ products|length }} ; i++) {
+            let index = i;
             setTimeout(function () {
                 renderCanvasData(`Ref${index}`, `Out${index}`, `Diff${index}`, 0.0)
             }, 100);
-        });
+        }
     })
 </script>

--- a/templates/main_template.html
+++ b/templates/main_template.html
@@ -170,7 +170,7 @@
 
 <script>
     $(document).ready(function() {
-        for (var i = 1; i <= {{ products|length }} ; i++) {
+        for (var i = 1; i <= {{ cases_list|length }} ; i++) {
             let index = i;
             setTimeout(function () {
                 renderCanvasData(`Ref${index}`, `Out${index}`, `Diff${index}`, 0.0)

--- a/templates/main_template.html
+++ b/templates/main_template.html
@@ -129,7 +129,7 @@
             </thead>
             <tbody>
                 {% for case in cases_list %}
-                <tr id="TRow{{ loop.index }}">
+                <tr key-number-original-order="{{ loop.index }}">
                     <td>{{ case['name'] }}</td>
                     <td>
                         <button class="btn btn-default" type="button" name="copyTestCaseNameButton" style="max-width: 15vw; margin: auto; display: block; white-space: break-spaces; overflow-wrap: break-word;">{{ case['name'] }}</button>
@@ -169,12 +169,17 @@
 </html>
 
 <script>
-    $(document).ready(function() {
-        for (var i = 1; i <= {{ cases_list|length }} ; i++) {
-            let index = i;
-            setTimeout(function () {
-                renderCanvasData(`Ref${index}`, `Out${index}`, `Diff${index}`, 0.0)
-            }, 100);
-        }
-    })
+    setTimeout(function () {
+        let table = $('#mainTable');
+        let rows = [...table[0].rows];
+        rows = rows.map( row => +row["key-number-original-order"] ).filter(row => !isNaN(row));
+
+        $(document).ready(function() {
+            rows.forEach(index => {
+                setTimeout(function () {
+                    renderCanvasData(`Ref${index}`, `Out${index}`, `Diff${index}`, 0.0)
+                }, 100);
+            });
+        });
+    }, 200);
 </script>

--- a/templates/main_template.html
+++ b/templates/main_template.html
@@ -129,7 +129,7 @@
             </thead>
             <tbody>
                 {% for case in cases_list %}
-                <tr key-number-original-order="{{ loop.index }}">
+                <tr data-unique-id="{{ loop.index }}">
                     <td>{{ case['name'] }}</td>
                     <td>
                         <button class="btn btn-default" type="button" name="copyTestCaseNameButton" style="max-width: 15vw; margin: auto; display: block; white-space: break-spaces; overflow-wrap: break-word;">{{ case['name'] }}</button>
@@ -169,17 +169,32 @@
 </html>
 
 <script>
-    setTimeout(function () {
-        let table = $('#mainTable');
-        let rows = [...table[0].rows];
-        rows = rows.map( row => +row["key-number-original-order"] ).filter(row => !isNaN(row));
+    $(document).ready(function() {
+        let fullLen = {{ cases_list|length }};
 
-        $(document).ready(function() {
-            rows.forEach(index => {
+        setTimeout(function () {
+            let table = $('#mainTable');
+            let rows = [...table[0].rows];
+
+            rows = rows
+                    .map( row => row.attributes["data-unique-id"] )
+                    .filter( row => !!row )
+                    .map( row => +row.value )
+                    .filter( row => !isNaN(row) );
+
+            rows.forEach((row, i) => {
                 setTimeout(function () {
-                    renderCanvasData(`Ref${index}`, `Out${index}`, `Diff${index}`, 0.0)
-                }, 100);
+                    renderCanvasData(`Ref${row}`, `Out${row}`, `Diff${row}`, 0.0);
+                }, 10 * i);
             });
-        });
-    }, 200);
+
+            // for rows that was not find in rows (does not execute usually)
+            for (var i = 0; i < fullLen; i++) {
+                if (rows.indexOf(i) > -1) continue;
+                setTimeout(function () {
+                    renderCanvasData(`Ref${i}`, `Out${i}`, `Diff${i}`, 0.0);
+                }, 10 * i);
+            }
+        }, 100);
+    });
 </script>

--- a/templates/main_template.html
+++ b/templates/main_template.html
@@ -170,8 +170,9 @@
 
 <script>
     let table = $('#mainTable')[0];
-    let rows = table.rows;
-    let order = rows.map(row => +row.id.replace("TRow"));
+    let rows = [...table.rows];
+    let order = rows.map(row => +row.id.replace("TRow")).filter(row => !isNaN(row));
+    console.log({orderLen: order.length})
 
     $(document).ready(function() {
         order.forEach(index => {

--- a/templates/main_template.html
+++ b/templates/main_template.html
@@ -106,7 +106,7 @@
                data-show-columns="true"
                data-show-pagination-switch="true"
                data-pagination="true"
-               data-page-size="ALL"
+               data-page-size="{{cases_list|length}}"
                data-page-list="[1, 5, 10, 20, 45, ALL]"
                data-sort-order="asc"
                data-sort-name="test_case">

--- a/templates/main_template.html
+++ b/templates/main_template.html
@@ -105,8 +105,8 @@
                data-show-toggle="false"
                data-show-columns="true"
                data-show-pagination-switch="true"
-               data-pagination="false"
-               data-page-size="5"
+               data-pagination="true"
+               data-page-size="10"
                data-page-list="[1, 5, 10, 20, 45, ALL]"
                data-sort-order="asc"
                data-sort-name="test_case">
@@ -169,32 +169,29 @@
 </html>
 
 <script>
-    $(document).ready(function() {
-        let fullLen = {{ cases_list|length }};
+    function setDiffImages() {
+        let table = $('#mainTable');
+        let rows = [...table[0].rows];
 
-        setTimeout(function () {
-            let table = $('#mainTable');
-            let rows = [...table[0].rows];
+        rows = rows
+                .map( row => row.attributes["data-unique-id"] )
+                .filter( row => !!row )
+                .map( row => +row.value )
+                .filter( row => !isNaN(row) );
 
-            rows = rows
-                    .map( row => row.attributes["data-unique-id"] )
-                    .filter( row => !!row )
-                    .map( row => +row.value )
-                    .filter( row => !isNaN(row) );
+        rows.forEach((row, i) => {
+            setTimeout(function () {
+                renderCanvasData(`Ref${row}`, `Out${row}`, `Diff${row}`, 0.0);
+            }, 10 * i);
+        });
+    }
 
-            rows.forEach((row, i) => {
-                setTimeout(function () {
-                    renderCanvasData(`Ref${row}`, `Out${row}`, `Diff${row}`, 0.0);
-                }, 10 * i);
-            });
+   $(document).ready(function() {
+        setTimeout(setDiffImages, 100);
 
-            // for rows that was not find in rows (does not execute usually)
-            for (var i = 0; i < fullLen; i++) {
-                if (rows.indexOf(i) > -1) continue;
-                setTimeout(function () {
-                    renderCanvasData(`Ref${i}`, `Out${i}`, `Diff${i}`, 0.0);
-                }, 10 * i);
-            }
-        }, 100);
+        let table = $('#mainTable');
+        table.on("page-change.bs.table", () => {
+            setTimeout(setDiffImages, 50);
+        });
     });
 </script>

--- a/templates/main_template.html
+++ b/templates/main_template.html
@@ -106,7 +106,7 @@
                data-show-columns="true"
                data-show-pagination-switch="true"
                data-pagination="true"
-               data-page-size="10"
+               data-page-size="ALL"
                data-page-list="[1, 5, 10, 20, 45, ALL]"
                data-sort-order="asc"
                data-sort-name="test_case">
@@ -186,7 +186,7 @@
         });
     }
 
-   $(document).ready(function() {
+    $(document).ready(function() {
         setTimeout(setDiffImages, 100);
 
         let table = $('#mainTable');


### PR DESCRIPTION
### Purpose
- Load images diff quicklier and by order on page

### Effect of change
- Images diff appears in correct order, added pagination

### Technical steps
- Add waitImageLoading function
- remove waitImgLoadAndRenderCanvasData because using waitImageLoading don't need a loop
- Add renderCanvasData for all images once after document ready
- Reduce interval between two diffs counting

### Jenkins Builds
- https://rpr.cis.luxoft.com/job/RadeonProRender-HybridManual/590/